### PR TITLE
First cut changes for Android auto deep linking

### DIFF
--- a/Branch-SDK-TestBed/AndroidManifest.xml
+++ b/Branch-SDK-TestBed/AndroidManifest.xml
@@ -31,16 +31,24 @@
             	<category android:name="android.intent.category.BROWSABLE" />
         	</intent-filter>
         </activity>
-        <activity
-            android:name="io.branch.branchandroiddemo.CreditHistoryActivity">
-        </activity>
-        <activity
-            android:name="io.branch.branchandroiddemo.ReferralCodeActivity">
+
+        <activity android:name="io.branch.branchandroiddemo.CreditHistoryActivity"/>
+
+        <activity android:name="io.branch.branchandroiddemo.ReferralCodeActivity"/>
+
+        <activity android:name=".AutoDeepLinkTestActivity">
+            <!-- Keys for auto deep linking this activity -->
+            <meta-data android:name="io.branch.sdk.auto_link_keys" android:value="auto_deeplink_key_1,auto_deeplink_key_2" />
+            <!-- Optional request ID for launching this activity on auto deep link key matches -->
+            <meta-data android:name="io.branch.sdk.auto_link_request_code" android:value="201" />
         </activity>
 
         <meta-data android:name="io.branch.sdk.TestMode" android:value="false" /> <!-- Set to true to use Branch_Test_Key -->
         <meta-data android:name="io.branch.sdk.BranchKey" android:value="key_live_jbgnjxvlhSb6PGH23BhO4hiflcp3y8kx" />
         <meta-data android:name="io.branch.sdk.BranchKey.test" android:value="key_test_jkptOCZtmtxhOMZ11ynbXecdDCd93cbr" />
+
+        <!-- Optional. Set to true to disable auto deep link feature-->
+        <meta-data android:name="io.branch.sdk.auto_link_disable" android:value="false"/>
 
         <uses-library android:name="android.test.runner" />
     </application>

--- a/Branch-SDK-TestBed/AndroidManifest.xml
+++ b/Branch-SDK-TestBed/AndroidManifest.xml
@@ -53,12 +53,23 @@
         <uses-library android:name="android.test.runner" />
 
         <!-- Add this for branch for install referrer tracking-->
-        <receiver
-            android:name="io.branch.referral.InstallListener" android:exported="true">
+        <receiver android:name="io.branch.referral.InstallListener" android:exported="true">
             <intent-filter>
                 <action android:name="com.android.vending.INSTALL_REFERRER" />
             </intent-filter>
         </receiver>
+
+
+       <!-- If you are  using custom install listener and still want to notify Branch on install, you can do one  of the following
+            1) Extend your receiver class with {@link InstallListener}
+                            Or
+            2) If you don't want to extend from {@link InstallListener} create an instance of {@link InstallListener} in your receiver's onReceive() method
+               and call InstallListener#onReceive() method.-->
+        <!--<receiver android:name="io.branch.branchandroiddemo.CustomInstallListener" android:exported="true">-->
+            <!--<intent-filter>-->
+                <!--<action android:name="com.android.vending.INSTALL_REFERRER" />-->
+            <!--</intent-filter>-->
+        <!--</receiver>-->
 
     </application>
 

--- a/Branch-SDK-TestBed/AndroidManifest.xml
+++ b/Branch-SDK-TestBed/AndroidManifest.xml
@@ -40,7 +40,7 @@
             <!-- Keys for auto deep linking this activity -->
             <meta-data android:name="io.branch.sdk.auto_link_keys" android:value="auto_deeplink_key_1,auto_deeplink_key_2" />
             <!-- Optional request ID for launching this activity on auto deep link key matches -->
-            <meta-data android:name="io.branch.sdk.auto_link_request_code" android:value="201" />
+            <meta-data android:name="io.branch.sdk.auto_link_request_code" android:value="@integer/AutoDeeplinkRequestCode" />
         </activity>
 
         <meta-data android:name="io.branch.sdk.TestMode" android:value="false" /> <!-- Set to true to use Branch_Test_Key -->

--- a/Branch-SDK-TestBed/AndroidManifest.xml
+++ b/Branch-SDK-TestBed/AndroidManifest.xml
@@ -51,6 +51,15 @@
         <meta-data android:name="io.branch.sdk.auto_link_disable" android:value="false"/>
 
         <uses-library android:name="android.test.runner" />
+
+        <!-- Add this for branch for install referrer tracking-->
+        <receiver
+            android:name="io.branch.referral.InstallListener" android:exported="true">
+            <intent-filter>
+                <action android:name="com.android.vending.INSTALL_REFERRER" />
+            </intent-filter>
+        </receiver>
+
     </application>
 
     <instrumentation

--- a/Branch-SDK-TestBed/res/layout/auto_deep_link_test.xml
+++ b/Branch-SDK-TestBed/res/layout/auto_deep_link_test.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/black">
+
+
+    <TextView
+        android:id="@+id/launch_mode_txt"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:gravity="center"
+        android:text="This activity is launched on auto deep linking!"
+        android:textAppearance="@android:style/TextAppearance.Medium"
+        android:textColor="@android:color/white"
+        android:padding="5dp"
+        />
+
+</RelativeLayout>

--- a/Branch-SDK-TestBed/res/values/integers.xml
+++ b/Branch-SDK-TestBed/res/values/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="AutoDeeplinkRequestCode">1001</integer>
+</resources>

--- a/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/AutoDeepLinkTestActivity.java
+++ b/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/AutoDeepLinkTestActivity.java
@@ -1,0 +1,39 @@
+package io.branch.branchandroiddemo;
+
+import android.app.Activity;
+import android.widget.TextView;
+
+import org.json.JSONException;
+
+import io.branch.referral.Branch;
+
+/**
+ * Created by sojanpr on 7/21/15.
+ * <p> Activity to demonstrate  the auto deep linking functionality.
+ * This activity is defined in the manifest with Keys for auto deep linking.
+ * See manifest file for auto deep link configurations.</p>
+ */
+public class AutoDeepLinkTestActivity extends Activity {
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        setContentView(R.layout.auto_deep_link_test);
+
+        TextView launch_mode_txt = (TextView) findViewById(R.id.launch_mode_txt);
+        if (Branch.isAutoDeepLinkLaunch(this)) {
+            try {
+                String autoDeeplinkedValue = Branch.getInstance().getLatestReferringParams().getString("auto_deeplink_key_1");
+                launch_mode_txt.setText("Launched by Branch on auto deep linking!"
+                        + "\n\n" + autoDeeplinkedValue);
+                Branch.getInstance().getLatestReferringParams();
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+
+        } else {
+            launch_mode_txt.setText("Launched by normal application flow");
+        }
+
+    }
+}

--- a/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/CustomInstallListener.java
+++ b/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/CustomInstallListener.java
@@ -3,16 +3,6 @@ package io.branch.branchandroiddemo;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.util.Log;
-
-import com.google.android.gms.tagmanager.InstallReferrerReceiver;
-
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-import java.util.Comparator;
-import java.util.Formatter;
-import java.util.HashMap;
-import java.util.IllegalFormatCodePointException;
 
 import io.branch.referral.InstallListener;
 

--- a/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/CustomInstallListener.java
+++ b/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/CustomInstallListener.java
@@ -1,0 +1,40 @@
+package io.branch.branchandroiddemo;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+import com.google.android.gms.tagmanager.InstallReferrerReceiver;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.Comparator;
+import java.util.Formatter;
+import java.util.HashMap;
+import java.util.IllegalFormatCodePointException;
+
+import io.branch.referral.InstallListener;
+
+
+/**
+ * Created by sojanpr on 7/23/15.
+ * Custom Class  to handle the install referrer broadcast .This should be used to receive the
+ * Install Referrer broadcast when it is needed to send install referrer info to multiple clients
+ */
+public class CustomInstallListener extends BroadcastReceiver{
+    @Override
+    public void onReceive(Context context, Intent intent) {
+
+        //Inform Branch Install listener about the install
+        InstallListener listener = new InstallListener();
+        listener.onReceive(context, intent);
+//
+//        In case you want to use  multiple listeners for install Add other install referrer listeners here.
+//        Below example shows how to do it for Google Analytics
+        
+//        InstallReferrerReceiver receiver = new InstallReferrerReceiver();
+//        receiver.onReceive(Context context, Intent intent);
+
+    }
+}

--- a/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
+++ b/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
@@ -278,7 +278,7 @@ public class MainActivity extends Activity {
 								Log.i("BranchTestBed", "onChannelSelected... " + channelName);
 							}
 						})
-						.ShareLink();
+						.shareLink();
 			}
 		});
 	}

--- a/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
+++ b/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
@@ -243,6 +243,7 @@ public class MainActivity extends Activity {
 				JSONObject obj = new JSONObject();
 				try {
 					obj.put("name", "test name");
+					obj.put("auto_deeplink_key_1", "This is an auto deep linked value");
 					obj.put("message", "hello there with short url");
 					obj.put("$og_title", "this is new sharing title");
 					obj.put("$og_description", "this is new sharing description");

--- a/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
+++ b/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
@@ -337,4 +337,17 @@ public class MainActivity extends Activity {
 		}
 	}
 
+	@Override
+	protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+		super.onActivityResult(requestCode, resultCode, data);
+
+		//Checking if the previous activity is launched on branch Auto deep link.
+		if(requestCode == getResources().getInteger(R.integer.AutoDeeplinkRequestCode)){
+			//Decide here where  to navigate  when an auto deep linked activity finishes.
+			//For e.g. Go to HomeActivity or a  SignUp Activity.
+			Intent i = new Intent(getApplicationContext(), CreditHistoryActivity.class);
+			startActivity(i);
+
+		}
+	}
 }

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -3335,7 +3335,7 @@ public class Branch {
 		 * <p>Creates an application selector dialog and share a link with user selected sharing option.
 		 * The link is created with the parameteres provided to the builder. </p>
 		 */
-		public void ShareLink() {
+		public void shareLink() {
 			branchReferral_.shareLink(this);
 		}
 

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -337,8 +337,6 @@ public class Branch {
 	/* Request code  used to launch and activity on auto deep linking unless DEF_AUTO_DEEP_LINK_REQ_CODE is not specified for teh activity in manifest.*/
 	private final int DEF_AUTO_DEEP_LINK_REQ_CODE = 1501;
 
-
-
 	/**
 	 * <p>The main constructor of the Branch class is private because the class uses the Singleton
 	 * pattern.</p>
@@ -2645,7 +2643,7 @@ public class Branch {
 		if (hasUser()) {
 			registerInstallOrOpen(new ServerRequestRegisterOpen(context_, callback, kRemoteInterface_.getSystemObserver()), callback);
 		} else {
-			registerInstallOrOpen(new ServerRequestRegisterInstall(context_, callback, kRemoteInterface_.getSystemObserver(), PrefHelper.NO_STRING_VALUE), callback);
+			registerInstallOrOpen(new ServerRequestRegisterInstall(context_, callback, kRemoteInterface_.getSystemObserver(), InstallListener.getInstallationID()), callback);
 		}
 	}
 
@@ -3381,4 +3379,5 @@ public class Branch {
 			return defaultURL_;
 		}
 	}
+
 }

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -5,6 +5,11 @@ import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ActivityInfo;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;
@@ -314,8 +319,25 @@ public class Branch {
 	/* Holds the current Session state. Default is set to UNINITIALISED. */
 	private SESSION_STATE initState_ = SESSION_STATE.UNINITIALISED;
 
-	/* Instance  of share link manager to share links automatically with thirdparty applications. */
+	/* Instance  of share link manager to share links automatically with third party applications. */
 	private ShareLinkManager shareLinkManager_;
+
+	/*The current activity instance for the application.*/
+	private Activity currentActivity_;
+
+	/* Key for Auto Deep link param. The activities which need to automatically deep linked should define in this in the activity metadata. */
+	private static final String AUTO_DEEP_LINK_KEY = "io.branch.sdk.auto_link_keys";
+
+	/* Key for disabling auto deep link feature. Setting this to true in manifest will disable auto deep linking feature. */
+	private static final String AUTO_DEEP_LINK_DISABLE = "io.branch.sdk.auto_link_disable";
+
+	/*Key for defining a request code for an activity. should be added as a metadata for an activity. This is used as a request code for launching a an activity on auto deep link. */
+	private final String AUTO_DEEP_LINK_REQ_CODE = "io.branch.sdk.auto_link_request_code";
+
+	/* Request code  used to launch and activity on auto deep linking unless DEF_AUTO_DEEP_LINK_REQ_CODE is not specified for teh activity in manifest.*/
+	private final int DEF_AUTO_DEEP_LINK_REQ_CODE = 1501;
+
+
 
 	/**
 	 * <p>The main constructor of the Branch class is private because the class uses the Singleton
@@ -837,6 +859,7 @@ public class Branch {
 	}
 
 	private void initUserSessionInternal(BranchReferralInitListener callback, Activity activity) {
+		currentActivity_ = activity;
 		//If already initialised
 		if (hasUser() && hasSession() && initState_ == SESSION_STATE.INITIALISED) {
 			if (callback != null)
@@ -2697,6 +2720,7 @@ public class Branch {
 
 		@Override
 		public void onActivityResumed(Activity activity) {
+			currentActivity_ = activity;
 			//Set the activity for touch debug
 			if (prefHelper_.getTouchDebugging()) {
 				setTouchDebugInternal(activity);
@@ -2919,6 +2943,7 @@ public class Branch {
 						if (thisReq_.isSessionInitRequest()) {
 							updateAllRequestsInQueue();
 							initState_ = SESSION_STATE.INITIALISED;
+							checkForAutoDeepLinkConfiguration();
 						}
 						requestQueue_.dequeue();
 					}
@@ -2933,6 +2958,80 @@ public class Branch {
 		}
 	}
 
+	//-------------------Auto deep link feature-------------------------------------------//
+
+	/**
+	 * <p>Checks if an activity is launched by Branch auto deep link feature. Branch launches activitie configured for auto deep link on seeing matching keys.
+	 * Keys for auto deep linking should be specified to each activity as a meta data in manifest.</p>
+	 * <p>
+	 * Configure your activity in your manifest to enable auto deep linking as follows
+	 * <activity android:name=".YourActivity">
+	 * <meta-data android:name="io.branch.sdk.auto_link" android:value="DeepLinkKey1","DeepLinkKey2" />
+	 * </activity>
+	 * </p>
+	 *
+	 * @param activity Instane of activity to check if launched on auto deep link.
+	 * @return A {Boolean} value whose value is true if this activity is launched by Branch auto deeplink feature.
+	 */
+	public static boolean isAutoDeepLinkLaunch(Activity activity) {
+		return (activity.getIntent().getStringExtra(AUTO_DEEP_LINK_KEY) != null);
+	}
+
+	private void checkForAutoDeepLinkConfiguration() {
+		JSONObject latestParams = getLatestReferringParams();
+		String deepLinkActivity = null;
+		String deepLinkKey = null;
+
+		try {
+			//Check if the application is launched by clicking a Branch link.
+			if (latestParams.has(Defines.Jsonkey.Clicked_Branch_Link.getKey()) == false
+					|| latestParams.getBoolean(Defines.Jsonkey.Clicked_Branch_Link.getKey()) == false) {
+				return;
+			}
+
+			if (latestParams.length() > 0) {
+				// Check if auto deep link is disabled.
+				ApplicationInfo appInfo = context_.getPackageManager().getApplicationInfo(context_.getPackageName(), PackageManager.GET_META_DATA);
+				if (appInfo.metaData != null && appInfo.metaData.getBoolean(AUTO_DEEP_LINK_DISABLE, false)) {
+					return;
+				}
+				PackageInfo info = context_.getPackageManager().getPackageInfo(context_.getPackageName(), PackageManager.GET_ACTIVITIES | PackageManager.GET_META_DATA);
+				ActivityInfo[] activityInfos = info.activities;
+				int deepLinkActivity_Req_Code = DEF_AUTO_DEEP_LINK_REQ_CODE;
+
+				for (ActivityInfo activityInfo : activityInfos) {
+					if (activityInfo.metaData != null && activityInfo.metaData.getString(AUTO_DEEP_LINK_KEY, null) != null) {
+						String[] activityLinkKeys = activityInfo.metaData.getString(AUTO_DEEP_LINK_KEY).split(",");
+						for (String activityLinkKey : activityLinkKeys) {
+							if (latestParams.has(activityLinkKey)) {
+								deepLinkActivity = ((ActivityInfo) activityInfo).name;
+								deepLinkActivity_Req_Code = activityInfo.metaData.getInt(AUTO_DEEP_LINK_REQ_CODE, DEF_AUTO_DEEP_LINK_REQ_CODE);
+								deepLinkKey = activityLinkKey;
+								break;
+							}
+						}
+					}
+					if (deepLinkActivity != null) {
+						break;
+					}
+				}
+				if (deepLinkActivity != null && currentActivity_ != null) {
+					Intent intent = new Intent(currentActivity_, Class.forName(deepLinkActivity));
+					intent.putExtra(AUTO_DEEP_LINK_KEY, deepLinkKey);
+					currentActivity_.startActivityForResult(intent, deepLinkActivity_Req_Code);
+				} else {
+					Log.d("BranchSDK", "No Activity found matching for auto deep linking");
+				}
+			}
+		} catch (final PackageManager.NameNotFoundException e) {
+			Log.i("BranchSDK", "Branch Warning: Please make sure Activity names set for auto deep link are correct!");
+		} catch (ClassNotFoundException e) {
+			Log.i("BranchSDK", "Branch Warning: Please make sure Activity names set for auto deep link are correct! Error while looking for activity " + deepLinkActivity);
+		} catch (JSONException ignore) {
+		}
+	}
+
+	//--------------------Window callback handling for touch debug feature-----------------------//
 
 
 	public class BranchWindowCallback implements Window.Callback {

--- a/Branch-SDK/src/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/io/branch/referral/Defines.java
@@ -59,7 +59,9 @@ class Defines {
         ScreenDpi("screen_dpi"),
         ScreenHeight("screen_height"),
         ScreenWidth("screen_width"),
-        WiFi("wifi");
+        WiFi("wifi"),
+        Clicked_Branch_Link("+clicked_branch_link"),
+        IsFirstSession("+is_first_session");
 
 
         private String key = "";

--- a/Branch-SDK/src/io/branch/referral/InstallListener.java
+++ b/Branch-SDK/src/io/branch/referral/InstallListener.java
@@ -3,7 +3,6 @@ package io.branch.referral;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.os.Bundle;
 import android.util.Log;
 
 import java.io.UnsupportedEncodingException;
@@ -37,7 +36,7 @@ public class InstallListener extends BroadcastReceiver {
 
                 for (String referrerParam : referralParams) {
                     String[] keyValue  =  referrerParam.split("=");
-                    referrerMap.put(URLDecoder.decode(keyValue[0]),URLDecoder.decode(keyValue[1]));
+                    referrerMap.put(URLDecoder.decode(keyValue[0],"UTF-8"),URLDecoder.decode(keyValue[1],"UTF-8"));
                     Log.d("installTest", keyValue[0] +" = " + keyValue[1]);
                 }
 

--- a/Branch-SDK/src/io/branch/referral/InstallListener.java
+++ b/Branch-SDK/src/io/branch/referral/InstallListener.java
@@ -1,0 +1,57 @@
+package io.branch.referral;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.HashMap;
+
+/**
+ * <p> Class for listening installation referrer params. Add this class to your manifest in order to get a referrer info </p>
+ *
+ * <p> Add to InstallListener to manifest as follows
+     <receiver android:name="io.branch.referral.InstallListener" android:exported="true">
+         <intent-filter>
+         <action android:name="com.android.vending.INSTALL_REFERRER" />
+         </intent-filter>
+     </receiver></p>
+ */
+public class InstallListener extends BroadcastReceiver {
+
+    /* Link identifier on installing app from play store. */
+    private static String installID_ =  PrefHelper.NO_STRING_VALUE;
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        Log.d("installTest", "InstallListener :- Received install referrer event");
+        String rawReferrerString = intent.getStringExtra("referrer");
+        if(rawReferrerString != null) {
+            try {
+                rawReferrerString = URLDecoder.decode(rawReferrerString, "UTF-8");
+                HashMap<String, String> referrerMap = new HashMap<String, String>();
+                String[] referralParams = rawReferrerString.split("&");
+
+                for (String referrerParam : referralParams) {
+                    String[] keyValue  =  referrerParam.split("=");
+                    referrerMap.put(URLDecoder.decode(keyValue[0]),URLDecoder.decode(keyValue[1]));
+                    Log.d("installTest", keyValue[0] +" = " + keyValue[1]);
+                }
+
+                if(referrerMap.containsKey(Defines.Jsonkey.LinkClickID.getKey())){
+                    installID_ = referrerMap.get(Defines.Jsonkey.LinkClickID.getKey());
+                }
+            } catch (UnsupportedEncodingException e) {
+                e.printStackTrace();
+            }
+
+        }
+    }
+
+    public static String getInstallationID(){
+        return installID_;
+    }
+}


### PR DESCRIPTION
First cut changes for Android Auto Deep link

@aaustin @shortstuffsushi 

 Note : The configurations for auto deep linking is done in manifest since devs will prefer less code changes.  Do we need to anticipate a situation where dev want to change auto deep linking params during run time?