### PR TITLE
 Set Debug Fix for Auto session mode

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -492,11 +492,7 @@ public class Branch {
         isAutoSessionMode_ = true;
         boolean isDebug = BranchUtil.isTestModeEnabled(context);
         getBranchInstance(context, !isDebug);
-        //Check if debug mode is debug is set in manifest.
-        if(isDebug) {
-            branchReferral_.setDebug();
-        }
-        branchReferral_.setActivityLifeCycleObserver((Application)context);
+        branchReferral_.setActivityLifeCycleObserver((Application) context);
         return branchReferral_;
     }
 
@@ -2557,8 +2553,8 @@ public class Branch {
         @Override
         public void onActivityStarted(Activity activity) {
             if (activityCnt_ < 1) { // Check if this is the first Activity.If so start a session.
-                //Check if debug mode is set in manifest. If so enable debug.
-                if(BranchUtil.isTestModeEnabled(context_)){
+                // Check if debug mode is set in manifest. If so enable debug.
+                if (BranchUtil.isTestModeEnabled(context_)) {
                     setDebug();
                 }
                 initSessionWithData(activity.getIntent().getData(), activity); // indicate  starting of session.

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -490,7 +490,12 @@ public class Branch {
     @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
     public static Branch getAutoInstance(Context context) {
         isAutoSessionMode_ = true;
-        getBranchInstance(context, true);
+        boolean isDebug = BranchUtil.isTestModeEnabled(context);
+        getBranchInstance(context, !isDebug);
+        //Check if debug mode is debug is set in manifest.
+        if(isDebug) {
+            branchReferral_.setDebug();
+        }
         branchReferral_.setActivityLifeCycleObserver((Application)context);
         return branchReferral_;
     }
@@ -2552,6 +2557,10 @@ public class Branch {
         @Override
         public void onActivityStarted(Activity activity) {
             if (activityCnt_ < 1) { // Check if this is the first Activity.If so start a session.
+                //Check if debug mode is set in manifest. If so enable debug.
+                if(BranchUtil.isTestModeEnabled(context_)){
+                    setDebug();
+                }
                 initSessionWithData(activity.getIntent().getData(), activity); // indicate  starting of session.
             }
             activityCnt_++;

--- a/Branch-SDK/src/io/branch/referral/BranchApp.java
+++ b/Branch-SDK/src/io/branch/referral/BranchApp.java
@@ -33,32 +33,10 @@ public class BranchApp extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-        if (isTestModeEnabled() == false) {
+        if (BranchUtil.isTestModeEnabled(this) == false) {
             Branch.getInstance(this);
         } else {
             Branch.getTestInstance(this);
         }
-    }
-
-    /**
-     * Get the value of "io.branch.sdk.TestMode" entry in application manifest.
-     *
-     * @return value of "io.branch.sdk.TestMode" entry in application manifest.
-     *         false if "io.branch.sdk.TestMode" is not added in the manifest.
-     */
-
-    private boolean isTestModeEnabled() {
-        boolean isTestMode_ = false;
-        String testModeKey = "io.branch.sdk.TestMode";
-        try {
-            final ApplicationInfo ai = getPackageManager().getApplicationInfo(getPackageName(), PackageManager.GET_META_DATA);
-            if (ai.metaData != null) {
-                isTestMode_ = ai.metaData.getBoolean(testModeKey, false);
-            }
-        } catch (final PackageManager.NameNotFoundException e) {
-            e.printStackTrace();
-        }
-
-        return isTestMode_;
     }
 }

--- a/Branch-SDK/src/io/branch/referral/BranchUtil.java
+++ b/Branch-SDK/src/io/branch/referral/BranchUtil.java
@@ -1,0 +1,37 @@
+package io.branch.referral;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Iterator;
+
+/**
+ * Class for Branch utility methods
+ */
+class BranchUtil {
+
+    /**
+     * Get the value of "io.branch.sdk.TestMode" entry in application manifest.
+     *
+     * @return value of "io.branch.sdk.TestMode" entry in application manifest.
+     * false if "io.branch.sdk.TestMode" is not added in the manifest.
+     */
+    public static boolean isTestModeEnabled(Context context) {
+        boolean isTestMode_ = false;
+        String testModeKey = "io.branch.sdk.TestMode";
+        try {
+            final ApplicationInfo ai = context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+            if (ai.metaData != null) {
+                isTestMode_ = ai.metaData.getBoolean(testModeKey, false);
+            }
+        } catch (final PackageManager.NameNotFoundException e) {
+            e.printStackTrace();
+        }
+
+        return isTestMode_;
+    }
+}


### PR DESCRIPTION
In Auto session mode  since  Branch is Intercepting the Activity Life
cycle methods and calling init session, User setting `setDebug()` has
no effect  on setting real/fake hardware ID. So Devs cannot test
Install  and `isFirstSession` with `setDebug` option

@qinweigong @aaustin 