### PR TITLE
Hot Fix for missing `setSubject()` method in Sharing builder

### DIFF
--- a/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
+++ b/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
@@ -263,6 +263,7 @@ public class MainActivity extends Activity {
                         .addPreferredSharingOption(SharingHelper.SHARE_WITH.MESSAGE)
                         .addPreferredSharingOption(SharingHelper.SHARE_WITH.TWITTER)
                         .setMessage("See my content")
+                        .setSubject("Check this out!")
                         .setStage("stage1")
                         .setFeature("feature1")
                         .addTag("Tag1")

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -3243,6 +3243,7 @@ public class Branch {
         private final Branch branch_;
 
         private String shareMsg_;
+        private String shareSub_;
         private Collection<String> tags_ = null;
         private String feature_ = "";
         private String stage_ = "";
@@ -3283,6 +3284,16 @@ public class Branch {
             return this;
         }
 
+        /**
+         * <p>Sets the subject of this message. This will be added to Email and SMS Application capable of handling subject in the message.</p>
+         *
+         * @param subject A {@link String} subject of this message.
+         * @return A {@link io.branch.referral.Branch.ShareLinkBuilder} instance.
+         */
+        public ShareLinkBuilder setSubject(String subject) {
+            this.shareSub_ = subject;
+            return this;
+        }
         /**
          * <p>Adds the given tag an iterable {@link Collection} of {@link String} tags associated with a deep
          * link.</p>
@@ -3358,7 +3369,7 @@ public class Branch {
 
         /**
          * <p>Creates an application selector dialog and share a link with user selected sharing option.
-         * The link is created with the parameteres provided to the builder. </p>
+         * The link is created with the parameters provided to the builder. </p>
          */
         public void shareLink() {
             branchReferral_.shareLink(this);
@@ -3379,6 +3390,11 @@ public class Branch {
         public String getShareMsg() {
             return shareMsg_;
         }
+
+        public String getShareSub() {
+            return shareSub_;
+        }
+
 
         public BranchLinkShareListener getCallback() {
             return callback_;

--- a/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
+++ b/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
@@ -40,6 +40,8 @@ class ShareLinkManager {
     Dialog shareDlg_;
     /* The message to be attached with the shared link */
     String shareMsg_;
+    /* The subject to be attached with the sharing message */
+    String shareSub_;
     /* Json object containing key-value pairs for the parameters to be linked. */
     JSONObject linkCreationParams_;
     /* Current Branch instance. */
@@ -76,6 +78,7 @@ class ShareLinkManager {
         stage_ = builder.getStage();
         linkCreationParams_ = builder.getLinkCreationParams();
         shareMsg_ = builder.getShareMsg();
+        shareSub_ = builder.getShareSub();
         branch_ = builder.getBranch();
         callback_ = builder.getCallback();
         defaultURL_ = builder.getDefaultURL();
@@ -241,6 +244,9 @@ class ShareLinkManager {
                 Log.i("BranchSDK", "Shared link with " + channelName);
             }
             shareLinkIntent_.setPackage(selectedResolveInfo.activityInfo.packageName);
+            if(shareSub_ != null && shareSub_.trim().length() > 0) {
+                shareLinkIntent_.putExtra(Intent.EXTRA_SUBJECT, shareSub_);
+            }
             shareLinkIntent_.putExtra(Intent.EXTRA_TEXT, shareMsg_ + "\n" + url);
             context_.startActivity(shareLinkIntent_);
         }


### PR DESCRIPTION
Adding missing builder method to set subject for email/sms share

@aaustin @shortstuffsushi 