### PR TITLE
Fixing Callback clearing issue 

### DIFF
--- a/Branch-SDK/src/io/branch/referral/ServerRequestRegisterInstall.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestRegisterInstall.java
@@ -3,6 +3,7 @@ package io.branch.referral;
 import android.app.Application;
 import android.content.Context;
 import android.util.DisplayMetrics;
+import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -129,7 +130,9 @@ class ServerRequestRegisterInstall extends ServerRequest {
     }
 
     public void setInitFinishedCallback(Branch.BranchReferralInitListener callback) {
-        callback_ = callback;
+        if(callback != null) {  // Update callback if set with valid callback instance.
+            callback_ = callback;
+        }
     }
 
     @Override

--- a/Branch-SDK/src/io/branch/referral/ServerRequestRegisterInstall.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestRegisterInstall.java
@@ -3,7 +3,6 @@ package io.branch.referral;
 import android.app.Application;
 import android.content.Context;
 import android.util.DisplayMetrics;
-import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/Branch-SDK/src/io/branch/referral/ServerRequestRegisterOpen.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestRegisterOpen.java
@@ -2,7 +2,6 @@ package io.branch.referral;
 
 import android.app.Application;
 import android.content.Context;
-import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/Branch-SDK/src/io/branch/referral/ServerRequestRegisterOpen.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestRegisterOpen.java
@@ -2,6 +2,7 @@ package io.branch.referral;
 
 import android.app.Application;
 import android.content.Context;
+import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -98,7 +99,9 @@ class ServerRequestRegisterOpen extends ServerRequest {
     }
 
     public void setInitFinishedCallback(Branch.BranchReferralInitListener callback) {
-        callback_ = callback;
+        if(callback != null) {      // Update callback if set with valid callback instance.
+            callback_ = callback;
+        }
     }
 
     @Override


### PR DESCRIPTION
When Called internally form auto session it used to remove the callback
with null (if user already called intisession() from anywhere else )

@Sarkar @aaustin 