### PR TITLE
Fix null intent on auto session management

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -2687,7 +2687,11 @@ public class Branch {
                 if (BranchUtil.isTestModeEnabled(context_)) {
                     setDebug();
                 }
-                initSessionWithData(activity.getIntent().getData(), activity); // indicate  starting of session.
+                Uri intentData = null;
+                if (activity.getIntent() != null) {
+                    intentData = activity.getIntent().getData();
+                }
+                initSessionWithData(intentData, activity); // indicate  starting of session.
             }
             activityCnt_++;
         }


### PR DESCRIPTION
@sojanpr We just had a crash report because I wasn’t checking if the
intent was null. This will handle the case.