### PR TITLE
Removing request on Conflict

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -2879,7 +2879,7 @@ public class Branch {
                         if (thisReq_.isSessionInitRequest()) {
                             initState_ = SESSION_STATE.UNINITIALISED;
                         }
-                        //On a bad request continue processing
+                        // On a bad request notify with call back and remove the request.
                         if (status == 409) {
                             if (thisReq_ instanceof ServerRequestCreateUrl) {
                                 ((ServerRequestCreateUrl) thisReq_).handleDuplicateURLError();
@@ -2887,6 +2887,7 @@ public class Branch {
                                 Log.i("BranchSDK", "Branch API Error: Conflicting resource error code from API");
                                 handleFailure(0, status);
                             }
+                            requestQueue_.remove(thisReq_);
                         }
                         //On Network error or Branch is down fail all the pending requests in the queue except
                         //for request which need to be replayed on failure.

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -2881,13 +2881,13 @@ public class Branch {
                         }
                         // On a bad request notify with call back and remove the request.
                         if (status == 409) {
+                            requestQueue_.remove(thisReq_);
                             if (thisReq_ instanceof ServerRequestCreateUrl) {
                                 ((ServerRequestCreateUrl) thisReq_).handleDuplicateURLError();
                             } else {
                                 Log.i("BranchSDK", "Branch API Error: Conflicting resource error code from API");
                                 handleFailure(0, status);
                             }
-                            requestQueue_.remove(thisReq_);
                         }
                         //On Network error or Branch is down fail all the pending requests in the queue except
                         //for request which need to be replayed on failure.


### PR DESCRIPTION
@aaustin @qinweigong  Removing a request from the request queue on
getting 409( Resource conflict). Originally we never removed the
request from the queue and always retried. Seeing this issue ,feel like
it is better to remove the request after notifying through the callback.
https://github.com/BranchMetrics/Android-Deferred-Deep-Linking-SDK/issue
s/130