### PR TITLE
Fixing issue Install params are updated link clicks

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -701,7 +701,7 @@ public class Branch {
      */
     public boolean initSession(BranchReferralInitListener callback, Activity activity) {
         if (customReferrableSettings_ == CUSTOM_REFERRABLE_SETTINGS.USE_DEFAULT) {
-            initUserSessionInternal(callback, activity, !hasUser());
+            initUserSessionInternal(callback, activity, true);
         } else {
             boolean isReferrable = customReferrableSettings_ == CUSTOM_REFERRABLE_SETTINGS.REFERRABLE;
             initUserSessionInternal(callback, activity, isReferrable);

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -507,8 +507,8 @@ public class Branch {
     public static Branch getAutoInstance(Context context) {
         isAutoSessionMode_ = true;
         customReferrableSettings_ = CUSTOM_REFERRABLE_SETTINGS.USE_DEFAULT;
-        boolean isDebug = BranchUtil.isTestModeEnabled(context);
-        getBranchInstance(context, !isDebug);
+        boolean isLive = !BranchUtil.isTestModeEnabled(context);
+        getBranchInstance(context, isLive);
         branchReferral_.setActivityLifeCycleObserver((Application) context);
         return branchReferral_;
     }

--- a/Branch-SDK/src/io/branch/referral/ServerRequestRegisterInstall.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestRegisterInstall.java
@@ -98,15 +98,22 @@ class ServerRequestRegisterInstall extends ServerRequest {
             prefHelper_.setSessionID(resp.getObject().getString(Defines.Jsonkey.SessionID.getKey()));
             prefHelper_.setLinkClickIdentifier(PrefHelper.NO_STRING_VALUE);
 
-            if (prefHelper_.getIsReferrable() == 1) {
-                if (resp.getObject().has(Defines.Jsonkey.Data.getKey())) {
-                    String params = resp.getObject().getString(Defines.Jsonkey.Data.getKey());
-                    prefHelper_.setInstallParams(params);
-                } else {
-                    prefHelper_.setInstallParams(PrefHelper.NO_STRING_VALUE);
+            if (resp.getObject().has(Defines.Jsonkey.Data.getKey())) {
+                JSONObject dataObj = new JSONObject(resp.getObject().getString(Defines.Jsonkey.Data.getKey()));
+                // If Clicked on a branch link
+                if (dataObj.has(Defines.Jsonkey.Clicked_Branch_Link.getKey())
+                        && dataObj.getBoolean(Defines.Jsonkey.Clicked_Branch_Link.getKey())) {
+
+                    // Check if there is any install params. Install param will be empty on until click a branch link
+                    // or When a user logout
+                    if (prefHelper_.getInstallParams().equals(PrefHelper.NO_STRING_VALUE)) {
+                        // if clicked on link then check for is Referrable state
+                        if (prefHelper_.getIsReferrable() == 1) {
+                            String params = resp.getObject().getString(Defines.Jsonkey.Data.getKey());
+                            prefHelper_.setInstallParams(params);
+                        }
+                    }
                 }
-                // Clear isReferrable inorder to prevent update of install params on successive open calls
-                prefHelper_.clearIsReferrable();
             }
 
             if (resp.getObject().has(Defines.Jsonkey.LinkClickID.getKey())) {

--- a/Branch-SDK/src/io/branch/referral/ServerRequestRegisterInstall.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestRegisterInstall.java
@@ -105,6 +105,8 @@ class ServerRequestRegisterInstall extends ServerRequest {
                 } else {
                     prefHelper_.setInstallParams(PrefHelper.NO_STRING_VALUE);
                 }
+                // Clear isReferrable inorder to prevent update of install params on successive open calls
+                prefHelper_.clearIsReferrable();
             }
 
             if (resp.getObject().has(Defines.Jsonkey.LinkClickID.getKey())) {

--- a/Branch-SDK/src/io/branch/referral/ServerRequestRegisterOpen.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestRegisterOpen.java
@@ -74,11 +74,16 @@ class ServerRequestRegisterOpen extends ServerRequest {
                 prefHelper_.setLinkClickID(PrefHelper.NO_STRING_VALUE);
             }
 
+            // If call "initSession(BranchReferralInitListener callback, boolean isReferrable, Activity activity)"
+            // User want to override install param update with isReferrable value. In this case we need to update the install
+            // param with latest link params in open or install call.
             if (prefHelper_.getIsReferrable() == 1) {
                 if (resp.getObject().has(Defines.Jsonkey.Data.getKey())) {
                     String params = resp.getObject().getString(Defines.Jsonkey.Data.getKey());
                     prefHelper_.setInstallParams(params);
                 }
+                // Clear isReferrable inorder to prevent update of install params on successive open calls.
+                prefHelper_.clearIsReferrable();
             }
 
             if (resp.getObject().has(Defines.Jsonkey.Data.getKey())) {

--- a/Branch-SDK/src/io/branch/referral/ServerRequestRegisterOpen.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestRegisterOpen.java
@@ -74,16 +74,22 @@ class ServerRequestRegisterOpen extends ServerRequest {
                 prefHelper_.setLinkClickID(PrefHelper.NO_STRING_VALUE);
             }
 
-            // If call "initSession(BranchReferralInitListener callback, boolean isReferrable, Activity activity)"
-            // User want to override install param update with isReferrable value. In this case we need to update the install
-            // param with latest link params in open or install call.
-            if (prefHelper_.getIsReferrable() == 1) {
-                if (resp.getObject().has(Defines.Jsonkey.Data.getKey())) {
-                    String params = resp.getObject().getString(Defines.Jsonkey.Data.getKey());
-                    prefHelper_.setInstallParams(params);
+            if (resp.getObject().has(Defines.Jsonkey.Data.getKey())) {
+                JSONObject dataObj = new JSONObject(resp.getObject().getString(Defines.Jsonkey.Data.getKey()));
+                // If Clicked on a branch link
+                if (dataObj.has(Defines.Jsonkey.Clicked_Branch_Link.getKey())
+                        && dataObj.getBoolean(Defines.Jsonkey.Clicked_Branch_Link.getKey())) {
+
+                    // Check if there is any install params. Install param will be empty on until click a branch link
+                    // or When a user logout
+                    if (prefHelper_.getInstallParams().equals(PrefHelper.NO_STRING_VALUE)) {
+                        // if clicked on link then check for is Referrable state
+                        if (prefHelper_.getIsReferrable() == 1) {
+                            String params = resp.getObject().getString(Defines.Jsonkey.Data.getKey());
+                            prefHelper_.setInstallParams(params);
+                        }
+                    }
                 }
-                // Clear isReferrable inorder to prevent update of install params on successive open calls.
-                prefHelper_.clearIsReferrable();
             }
 
             if (resp.getObject().has(Defines.Jsonkey.Data.getKey())) {


### PR DESCRIPTION
Fixed flow
- Update install params on Install only if user is not overriding
`isReferrable` field in initSessionCall.

- Update install params on any session init if user intentionally
override `isReferrable` field in initSessionCall.
 @aaustin  @Sarkar 
