### PR TITLE
Fixing issue :  Same params transmitted on all init calls

### DIFF
--- a/Branch-SDK/src/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequest.java
@@ -100,16 +100,6 @@ abstract class ServerRequest {
     }
 
     /**
-     * Returns true if this request is causing a session initialisation. Only open or Install request causes an init session.
-     * Request which initialise new session should override and handle accordingly.
-     *
-     * @return A {@link Boolean} whose value is true if this request causes a session initialisation.
-     */
-    public boolean isSessionInitRequest() {
-        return false;
-    }
-
-    /**
      * <p>Provides the path to server for this request.
      * see {@link Defines.RequestPath} <p>
      *

--- a/Branch-SDK/src/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestInitSession.java
@@ -1,0 +1,25 @@
+package io.branch.referral;
+
+import android.content.Context;
+
+import org.json.JSONObject;
+
+/**
+ * <p>
+ * Abstract for Session init request. All request which do initilaise session should extend from this.
+ * </p>
+ */
+abstract class ServerRequestInitSession extends ServerRequest {
+    public ServerRequestInitSession(Context context, String requestPath) {
+        super(context, requestPath);
+    }
+    protected ServerRequestInitSession(String requestPath, JSONObject post, Context context) {
+       super(requestPath, post, context);
+    }
+
+    /**
+     * Check if there is a valid callback to return init session result
+     * @return True if a valid call back is present.
+     */
+    public abstract boolean hasCallBack();
+}

--- a/Branch-SDK/src/io/branch/referral/ServerRequestRegisterInstall.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestRegisterInstall.java
@@ -12,7 +12,7 @@ import org.json.JSONObject;
  * The server request for registering an app install to Branch API. Handles request creation and execution.
  * </p>
  */
-class ServerRequestRegisterInstall extends ServerRequest {
+class ServerRequestRegisterInstall extends ServerRequestInitSession {
 
     Branch.BranchReferralInitListener callback_;
 
@@ -87,6 +87,11 @@ class ServerRequestRegisterInstall extends ServerRequest {
 
     public ServerRequestRegisterInstall(String requestPath, JSONObject post, Context context) {
         super(requestPath, post, context);
+    }
+
+    @Override
+    public boolean hasCallBack() {
+        return callback_ != null;
     }
 
     @Override
@@ -173,10 +178,5 @@ class ServerRequestRegisterInstall extends ServerRequest {
     @Override
     public void clearCallbacks() {
         callback_ = null;
-    }
-
-    @Override
-    public boolean isSessionInitRequest() {
-        return true; //Since open request causes a new session
     }
 }

--- a/Branch-SDK/src/io/branch/referral/ServerRequestRegisterOpen.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestRegisterOpen.java
@@ -11,7 +11,7 @@ import org.json.JSONObject;
  * The server request for registering an app open event to Branch API. Handles request creation and execution.
  * </p>
  */
-class ServerRequestRegisterOpen extends ServerRequest {
+class ServerRequestRegisterOpen extends ServerRequestInitSession {
 
     Branch.BranchReferralInitListener callback_;
 
@@ -147,7 +147,7 @@ class ServerRequestRegisterOpen extends ServerRequest {
     }
 
     @Override
-    public boolean isSessionInitRequest() {
-        return true; //Since open request causes a new session
+    public boolean hasCallBack() {
+        return callback_ != null;
     }
 }


### PR DESCRIPTION
IN Auto session management we were returning latest params with all
init call if the Branch is already initialized. This is due to the
reason that Init session is caused by Branch SDK in case of Auto
session and by the time user start an init session , session might be
already finished.

Added a fix to check if the init Params are  called back at lease once.
only affect the auto session

@aaustin @Sarkar 