### PR TITLE
Fixing issue : creating link before session init

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -921,7 +921,7 @@ public class Branch {
         }
         //If uninitialised or initialising
         else {
-            // In case of Auto session init will be called from banch before user. So initialising
+            // In case of Auto session init will be called from Branch before user. So initialising
             // State also need to look for isReferrable value
             if (isReferrable) {
                 this.prefHelper_.setIsReferrable();
@@ -2719,9 +2719,9 @@ public class Branch {
             if((req instanceof ServerRequestRegisterClose)){
                 Log.i(TAG, "Branch is not initialized, cannot close session");
                 return;
-            }
-            else{
-                initializeSession(null);
+            } else {
+                boolean isReferrable = prefHelper_.getIsReferrable() == 1;
+                initUserSessionInternal(null, currentActivity_, isReferrable);
             }
         }
         requestQueue_.enqueue(req);
@@ -3032,11 +3032,16 @@ public class Branch {
 
                         requestQueue_.dequeue();
 
-                        //If this request changes a session update the session-id to queued requests.
+                        // If this request changes a session update the session-id to queued requests.
                         if (thisReq_ instanceof ServerRequestInitSession) {
+                            // Immediately set session and Identity and update the pending request with the params
+                            prefHelper_.setSessionID(serverResponse.getObject().getString(Defines.Jsonkey.SessionID.getKey()));
+                            if (serverResponse.getObject().has(Defines.Jsonkey.IdentityID.getKey())) {
+                                prefHelper_.setIdentityID(serverResponse.getObject().getString(Defines.Jsonkey.IdentityID.getKey()));
+                            }
                             updateAllRequestsInQueue();
                             initState_ = SESSION_STATE.INITIALISED;
-                            //Publish success to listeners
+                            // Publish success to listeners
                             thisReq_.onRequestSucceeded(serverResponse, branchReferral_);
 
                             if (((ServerRequestInitSession) thisReq_).hasCallBack()) {

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -2712,16 +2712,20 @@ public class Branch {
     private void handleNewRequest(ServerRequest req) {
         //If not initialised put an open or install request in front of this request(only if this needs session)
         if (initState_ != SESSION_STATE.INITIALISED && (req instanceof ServerRequestInitSession) == false) {
-            if((req instanceof ServerRequestLogout)){
+            if ((req instanceof ServerRequestLogout)) {
                 Log.i(TAG, "Branch is not initialized, cannot logout");
                 return;
             }
-            if((req instanceof ServerRequestRegisterClose)){
+            if ((req instanceof ServerRequestRegisterClose)) {
                 Log.i(TAG, "Branch is not initialized, cannot close session");
                 return;
             } else {
-                boolean isReferrable = prefHelper_.getIsReferrable() == 1;
-                initUserSessionInternal(null, currentActivity_, isReferrable);
+                if (customReferrableSettings_ == CUSTOM_REFERRABLE_SETTINGS.USE_DEFAULT) {
+                    initUserSessionInternal(null, currentActivity_, true);
+                } else {
+                    boolean isReferrable = customReferrableSettings_ == CUSTOM_REFERRABLE_SETTINGS.REFERRABLE;
+                    initUserSessionInternal(null, currentActivity_, isReferrable);
+                }
             }
         }
         requestQueue_.enqueue(req);

--- a/Branch-SDK/src/io/branch/referral/ServerRequestQueue.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestQueue.java
@@ -202,6 +202,9 @@ class ServerRequestQueue {
      */
     public void insert(ServerRequest request, int index) {
         try {
+            if (queue.size() < index) {
+                index = queue.size();
+            }
             queue.add(index, request);
             persist();
         } catch (IndexOutOfBoundsException ignored) {

--- a/Branch-SDK/src/io/branch/referral/ServerRequestRegisterInstall.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestRegisterInstall.java
@@ -98,9 +98,7 @@ class ServerRequestRegisterInstall extends ServerRequestInitSession {
     public void onRequestSucceeded(ServerResponse resp, Branch branch) {
         try {
             prefHelper_.setDeviceFingerPrintID(resp.getObject().getString(Defines.Jsonkey.DeviceFingerprintID.getKey()));
-            prefHelper_.setIdentityID(resp.getObject().getString(Defines.Jsonkey.IdentityID.getKey()));
             prefHelper_.setUserURL(resp.getObject().getString(Defines.Jsonkey.Link.getKey()));
-            prefHelper_.setSessionID(resp.getObject().getString(Defines.Jsonkey.SessionID.getKey()));
             prefHelper_.setLinkClickIdentifier(PrefHelper.NO_STRING_VALUE);
 
             if (resp.getObject().has(Defines.Jsonkey.Data.getKey())) {

--- a/Branch-SDK/src/io/branch/referral/ServerRequestRegisterOpen.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestRegisterOpen.java
@@ -62,12 +62,8 @@ class ServerRequestRegisterOpen extends ServerRequestInitSession {
     @Override
     public void onRequestSucceeded(ServerResponse resp, Branch branch) {
         try {
-            prefHelper_.setSessionID(resp.getObject().getString(Defines.Jsonkey.SessionID.getKey()));
             prefHelper_.setDeviceFingerPrintID(resp.getObject().getString(Defines.Jsonkey.DeviceFingerprintID.getKey()));
             prefHelper_.setLinkClickIdentifier(PrefHelper.NO_STRING_VALUE);
-            if (resp.getObject().has(Defines.Jsonkey.IdentityID.getKey())) {
-                prefHelper_.setIdentityID(resp.getObject().getString(Defines.Jsonkey.IdentityID.getKey()));
-            }
             if (resp.getObject().has(Defines.Jsonkey.LinkClickID.getKey())) {
                 prefHelper_.setLinkClickID(resp.getObject().getString(Defines.Jsonkey.LinkClickID.getKey()));
             } else {


### PR DESCRIPTION
Fixing Issue from Partner
```There is a scenario in our partner's app in which they end up calling BranchShortLinkBuilder.getShortLink() before they get the BranchReferralInitListener.onInitFinished callback. In this case, the short-link generation fails.```

Please note that only Asynchronous  Link creation call ( generateShortURl()) will  only be served if called before Init session. getShortUrl() is a synchronous call and this will return null immediately if called before initialised.

@aaustin @derrickstaten @Sarkar 