### PR TITLE
Fixing a activity reference leak on Manual session

### DIFF
--- a/Branch-SDK-TestBed/build.gradle
+++ b/Branch-SDK-TestBed/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.application'
 dependencies {
     compile fileTree(dir: 'libs', include: '*.jar')
     compile project(':Branch-SDK')
-    debugCompile 'com.squareup.leakcanary:leakcanary-android:1.3.1'
+    debugCompile 'com.squareup.leakcanary:leakcanary-android:1.+'
     releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.3.1'
     compile ('com.google.android.gms:play-services:6.5.87'){
         exclude module: 'support-v4'

--- a/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/CustomBranchApp.java
+++ b/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/CustomBranchApp.java
@@ -1,10 +1,14 @@
 package io.branch.branchandroiddemo;
 
+import com.squareup.leakcanary.LeakCanary;
+
 import io.branch.referral.BranchApp;
 
 public final class CustomBranchApp extends BranchApp {
     @Override
     public void onCreate() {
         super.onCreate();
+        // Uncomment to test memory leak
+        // LeakCanary.install(this);
     }
 }

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -457,7 +457,7 @@ public class Branch {
                 branchReferral_.requestQueue_.clear();
             }
         }
-        branchReferral_.context_ = context;
+        branchReferral_.context_ = context.getApplicationContext();
 
         /* If {@link Application} is instantiated register for activity life cycle events. */
         if (context instanceof BranchApp) {
@@ -1059,22 +1059,28 @@ public class Branch {
             return;
         }
 
+
         if (prefHelper_.getSmartSession()) {
             if (keepAlive_) {
                 return;
             }
 
+
             // else, real close
-            synchronized(lock) {
+            synchronized (lock) {
                 clearCloseTimer();
                 rotateCloseTimer.schedule(new TimerTask() {
                     @Override
                     public void run() {
+                        //Since non auto session has no lifecycle callback enabled free up the currentActivity_
+                        currentActivity_ = null;
                         executeClose();
                     }
                 }, PREVENT_CLOSE_TIMEOUT);
             }
         } else {
+            //Since non auto session has no lifecycle callback enabled free up the currentActivity_
+            currentActivity_ = null;
             executeClose();
         }
 
@@ -1084,7 +1090,7 @@ public class Branch {
             }
         }
         /* Close any opened sharing dialog.*/
-        if(shareLinkManager_ != null) {
+        if (shareLinkManager_ != null) {
             shareLinkManager_.cancelShareLinkDialog(true);
         }
     }


### PR DESCRIPTION
On manual session there were couple of possible memory leak
1.`contenxt_`  is assigned with activity instance. This will keep the
first activity reference leaked .Changed to `context_ ` to save only
application context.

2. `currentActivity_` is saving the activity instance on each
initSessionCall() but up on calling  `closeSession` last activity
instance is  not freed up .

@aaustin @Sarkar @EvangelosG 