### PR TITLE
Fix :: Crash when data.getScheme() is null

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -1148,7 +1148,7 @@ public class Branch {
                 return true;
             } else {
                 // Check if the clicked url is an app link pointing to this app
-                if ((data.getScheme().equalsIgnoreCase("http") || data.getScheme().equalsIgnoreCase("https"))
+                if (("http".equalsIgnoreCase(data.getScheme()) || "https".equalsIgnoreCase(data.getScheme()))
                         && data.getHost() != null && data.getHost().length() > 0) {
                     prefHelper_.setAppLink(data.toString());
                 }


### PR DESCRIPTION
My application crashed when I started one of my activities and this was the stacktrace:

Fatal Exception: java.lang.RuntimeException: Unable to start activity ComponentInfo{com.olx.olx/com.olx.olx.ui.activities.ListingActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.String.equalsIgnoreCase(java.lang.String)' on a null object reference
       at android.app.ActivityThread.performLaunchActivity(ActivityThread.java)
       at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java)
       at android.app.ActivityThread.handleRelaunchActivity(ActivityThread.java)
       at android.app.ActivityThread.access$900(ActivityThread.java)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java)
       at android.os.Handler.dispatchMessage(Handler.java)
       at android.os.Looper.loop(Looper.java)
       at android.app.ActivityThread.main(ActivityThread.java)
       at java.lang.reflect.Method.invoke(Method.java)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java)
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.String.equalsIgnoreCase(java.lang.String)' on a null object reference
       at io.branch.referral.Branch.readAndStripParam(Branch.java)
       at io.branch.referral.Branch.initSessionWithData(Branch.java)
       at io.branch.referral.Branch$BranchActivityLifeCycleObserver.onActivityStarted(Branch.java)
       at android.app.Application.dispatchActivityStarted(Application.java)
       at android.app.Activity.onStart(Activity.java)
       at android.support.v4.app.FragmentActivity.onStart(FragmentActivity.java)
       at com.olx.olx.ui.activities.ServiceActivity.onStart(ServiceActivity.java)
       at android.app.Instrumentation.callActivityOnStart(Instrumentation.java)
       at android.app.Activity.performStart(Activity.java)

I was looking into your code and found that you are doing a comparison between data.getSchema() and two constants ("http" and "https"). A good way to avoid that crash is swapping the comparison between strings. In this case, we should put the constant first (which will never be null) and the variable that could be null inside the equalsIgnoreCase (which does the null comparison inside it).

I hope you find this useful.

Don't hesitate on reaching me out.