### PR TITLE
delayed update of install referrer

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -3160,6 +3160,18 @@ public class Branch {
                     || thisReq_ instanceof ServerRequestRegisterView) {
                 thisReq_.updateGAdsParams(systemObserver_);
             }
+
+            //In case of an install request, the referrer ID may take some time to update so wait for a second and update the install ID
+            if (thisReq_ instanceof ServerRequestRegisterInstall) {
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                } finally {
+                    ((ServerRequestRegisterInstall) thisReq_).updateInstallID(InstallListener.getInstallationID());
+                }
+            }
+
             if (thisReq_.isGetRequest()) {
                 return kRemoteInterface_.make_restful_get(thisReq_.getRequestUrl(), thisReq_.getRequestPath(), timeOut_);
             } else {

--- a/Branch-SDK/src/io/branch/referral/InstallListener.java
+++ b/Branch-SDK/src/io/branch/referral/InstallListener.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 public class InstallListener extends BroadcastReceiver {
 
     /* Link identifier on installing app from play store. */
-    private static String installID_ =  PrefHelper.NO_STRING_VALUE;
+    private static volatile String installID_ = PrefHelper.NO_STRING_VALUE;
 
     @Override
     public void onReceive(Context context, Intent intent) {

--- a/Branch-SDK/src/io/branch/referral/ServerRequestRegisterInstall.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestRegisterInstall.java
@@ -181,4 +181,15 @@ class ServerRequestRegisterInstall extends ServerRequestInitSession {
     public void clearCallbacks() {
         callback_ = null;
     }
+
+    public void updateInstallID(String installID) {
+        if (!installID.equals(PrefHelper.NO_STRING_VALUE)) {
+            try {
+                if (getPost() != null) {
+                    getPost().put(Defines.Jsonkey.LinkClickID.getKey(), installID);
+                }
+            } catch (JSONException ignore) {
+            }
+        }
+    }
 }


### PR DESCRIPTION
Since the install referrer value from play store app is provided as a
broadcast,  To support 100% install match,  the Register install
request is   delayed a bit in order to receive referrer broadcast .