### PR TITLE
Fixing a n intermittent crash issue

### DIFF
--- a/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
+++ b/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
@@ -157,9 +157,9 @@ class ShareLinkManager {
                     if (callback_ != null) {
                         callback_.onChannelSelected(((ResolveInfo) view.getTag()).loadLabel(context_.getPackageManager()).toString());
                     }
-                    invokeSharingClient((ResolveInfo) view.getTag());
                     adapter.selectedPos = pos;
                     adapter.notifyDataSetChanged();
+                    invokeSharingClient((ResolveInfo) view.getTag());
                     if (shareDlg_ != null) {
                         shareDlg_.cancel();
                     }
@@ -221,8 +221,6 @@ class ShareLinkManager {
                     }
                 }
                 isShareInProgress_ = false;
-                context_ = null;
-                builder_ = null;
             }
         });
     }


### PR DESCRIPTION
Making sure the  context is live until the share dialog is dismissed.
Release  the context only on dismissing Share dialog

@Sarkar @aaustin 