### PR TITLE
Add timings to server requests

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -4077,8 +4077,8 @@ public class Branch {
     }
 
     //------------------- Hidden method for adding timings ------------------//
-    public void addTiming(int timerId, long duration) {
+    public void addTiming(int timerId, long duration) throws Exception {
         if (timerId <= 1000) { throw new Exception("Timer ID must be greater than 1000"); }
-        prefHelper_.addTiming(timerId, duration);
+        prefHelper_.recordTiming(timerId, duration);
     }
 }

--- a/Branch-SDK/src/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/io/branch/referral/PrefHelper.java
@@ -993,14 +993,24 @@ public class PrefHelper {
         prefHelper_.prefsEditor_.commit();
     }
 
-    public void addTiming(int timerId, Long timerValue) {
+    /**
+     * <p>Records a length of time, associated with a duration.</p>
+     *
+     * @param timerId A value containing the id (effectively, the name) of the timer.
+     * @param duration The length of time.
+     */
+    public void recordTiming(int timerId, Long duration) {
         try {
             JSONObject existingTimings = new JSONObject(prefHelper_.appSharedPrefs_.getString(KEY_TIMINGS, "{}"));
-            existingTimings.put(Long.toString(timerId), timerValue);
+            existingTimings.put(Long.toString(timerId), duration);
             prefHelper_.prefsEditor_.putString(KEY_TIMINGS, existingTimings.toString());
         } catch (JSONException e) {}
     }
 
+    /**
+     * Get all stored up timings, and clear them out of the system.
+     * @return A map containing timing data (id -> duration).
+     */
     public JSONObject getTimings() {
         try {
             JSONObject timings = new JSONObject(prefHelper_.appSharedPrefs_.getString(KEY_TIMINGS, "{}"));

--- a/Branch-SDK/src/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/io/branch/referral/PrefHelper.java
@@ -9,6 +9,7 @@ import android.content.pm.PackageManager;
 import android.util.Log;
 
 import org.json.JSONException;
+import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -105,6 +106,8 @@ public class PrefHelper {
 
     private static final String KEY_EXTERNAL_INTENT_URI = "bnc_external_intent_uri";
     private static final String KEY_EXTERNAL_INTENT_EXTRA = "bnc_external_intent_extra";
+
+    private static final String KEY_TIMINGS = "bnc_timings";
 
     /**
      * {@link String} value used by {@link BranchRemoteInterface#connectToDebug()}.
@@ -988,6 +991,24 @@ public class PrefHelper {
     public void setBool(String key, Boolean value) {
         prefHelper_.prefsEditor_.putBoolean(key, value);
         prefHelper_.prefsEditor_.commit();
+    }
+
+    public void addTiming(int timerId, Long timerValue) {
+        try {
+            JSONObject existingTimings = new JSONObject(prefHelper_.appSharedPrefs_.getString(KEY_TIMINGS, "{}"));
+            existingTimings.put(Long.toString(timerId), timerValue);
+            prefHelper_.prefsEditor_.putString(KEY_TIMINGS, existingTimings.toString());
+        } catch (JSONException e) {}
+    }
+
+    public JSONObject getTimings() {
+        try {
+            JSONObject timings = new JSONObject(prefHelper_.appSharedPrefs_.getString(KEY_TIMINGS, "{}"));
+            prefHelper_.prefsEditor_.remove(KEY_TIMINGS);
+            return timings;
+        } catch (JSONException e) {
+            return null;
+        }
     }
 
     /**

--- a/Branch-SDK/src/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequest.java
@@ -22,6 +22,11 @@ public abstract class ServerRequest {
     /*True if there is an error in creating this request such as error with json parameters.*/
     public boolean constructError_ = false;
 
+    protected Integer queueTimerId_ = null;
+    protected Integer requestTimerId_ = null;
+    protected Long queueStartTimestamp_ = null;
+    protected Long requestStartTimestamp_ = null;
+
     /**
      * <p>Creates an instance of ServerRequest.</p>
      *
@@ -32,6 +37,7 @@ public abstract class ServerRequest {
         requestPath_ = requestPath;
         prefHelper_ = PrefHelper.getInstance(context);
         params_ = new JSONObject();
+        queueStartTimestamp_ = System.currentTimeMillis();
     }
 
     /**
@@ -260,6 +266,25 @@ public abstract class ServerRequest {
         }
 
         return extendedReq;
+    }
+
+    /**
+     * Add queue timing, and begin counting request timing.
+     */
+    public void timeRequestStart() {
+        requestStartTimestamp_ = System.currentTimeMillis();
+        if (queueTimerId_ != null && queueStartTimestamp_!= null) {
+            prefHelper_.addTiming(queueTimerId_, requestStartTimestamp_ - queueStartTimestamp_);
+        }
+    }
+
+    /**
+     * Finish request timing.
+     */
+    public void timeRequestEnd() {
+        if (queueTimerId_ != null && requestStartTimestamp_ != null) {
+            prefHelper_.addTiming(requestTimerId_, System.currentTimeMillis() - requestStartTimestamp_);
+        }
     }
 
     /**

--- a/Branch-SDK/src/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequest.java
@@ -274,7 +274,7 @@ public abstract class ServerRequest {
     public void timeRequestStart() {
         requestStartTimestamp_ = System.currentTimeMillis();
         if (queueTimerId_ != null && queueStartTimestamp_!= null) {
-            prefHelper_.addTiming(queueTimerId_, requestStartTimestamp_ - queueStartTimestamp_);
+            prefHelper_.recordTiming(queueTimerId_, requestStartTimestamp_ - queueStartTimestamp_);
         }
     }
 
@@ -283,7 +283,7 @@ public abstract class ServerRequest {
      */
     public void timeRequestEnd() {
         if (queueTimerId_ != null && requestStartTimestamp_ != null) {
-            prefHelper_.addTiming(requestTimerId_, System.currentTimeMillis() - requestStartTimestamp_);
+            prefHelper_.recordTiming(requestTimerId_, System.currentTimeMillis() - requestStartTimestamp_);
         }
     }
 

--- a/Branch-SDK/src/io/branch/referral/ServerRequestActionCompleted.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestActionCompleted.java
@@ -26,6 +26,8 @@ class ServerRequestActionCompleted extends ServerRequest {
      */
     public ServerRequestActionCompleted(Context context, String action, JSONObject metadata) {
         super(context, Defines.RequestPath.CompletedAction.getPath());
+        queueTimerId_ = 23;
+        requestTimerId_ = 24;
         JSONObject post = new JSONObject();
 
         try {

--- a/Branch-SDK/src/io/branch/referral/ServerRequestApplyReferralCode.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestApplyReferralCode.java
@@ -30,6 +30,8 @@ class ServerRequestApplyReferralCode extends ServerRequest {
         super(context, Defines.RequestPath.ApplyReferralCode.getPath());
 
         callback_ = callback;
+        queueTimerId_ = 21;
+        requestTimerId_ = 22;
         JSONObject post = new JSONObject();
         try {
             post.put(Defines.Jsonkey.IdentityID.getKey(), prefHelper_.getIdentityID());

--- a/Branch-SDK/src/io/branch/referral/ServerRequestCreateUrl.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestCreateUrl.java
@@ -60,6 +60,8 @@ class ServerRequestCreateUrl extends ServerRequest {
 
         callback_ = callback;
         isAsync_ = async;
+        queueTimerId_ = 19;
+        requestTimerId_ = 20;
 
         linkPost_ = new BranchLinkData();
         try {

--- a/Branch-SDK/src/io/branch/referral/ServerRequestGetReferralCode.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestGetReferralCode.java
@@ -47,6 +47,8 @@ class ServerRequestGetReferralCode extends ServerRequest {
                                         String bucket, int calculationType, int location, Branch.BranchReferralInitListener callback) {
         super(context, Defines.RequestPath.GetReferralCode.getPath());
         callback_ = callback;
+        queueTimerId_ = 17;
+        requestTimerId_ = 18;
 
         JSONObject post = new JSONObject();
         try {

--- a/Branch-SDK/src/io/branch/referral/ServerRequestGetReferralCount.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestGetReferralCount.java
@@ -25,6 +25,8 @@ class ServerRequestGetReferralCount extends ServerRequest {
      */
     public ServerRequestGetReferralCount(Context context, Branch.BranchReferralStateChangedListener callback) {
         super(context, Defines.RequestPath.Referrals.getPath());
+        queueTimerId_ = 15;
+        requestTimerId_ = 16;
         callback_ = callback;
     }
 

--- a/Branch-SDK/src/io/branch/referral/ServerRequestGetRewardHistory.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestGetRewardHistory.java
@@ -44,6 +44,8 @@ class ServerRequestGetRewardHistory extends ServerRequest {
 
         super(context, Defines.RequestPath.GetCreditHistory.getPath());
         callback_ = callback;
+        queueTimerId_ = 27;
+        requestTimerId_ = 28;
 
         JSONObject getCreditHistoryPost = new JSONObject();
         try {

--- a/Branch-SDK/src/io/branch/referral/ServerRequestGetRewards.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestGetRewards.java
@@ -29,6 +29,8 @@ class ServerRequestGetRewards extends ServerRequest {
     public ServerRequestGetRewards(Context context, Branch.BranchReferralStateChangedListener callback) {
         super(context, Defines.RequestPath.GetCredits.getPath());
         callback_ = callback;
+        queueTimerId_ = 25;
+        requestTimerId_ = 26;
     }
 
     public ServerRequestGetRewards(String requestPath, JSONObject post, Context context) {

--- a/Branch-SDK/src/io/branch/referral/ServerRequestIdentifyUserRequest.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestIdentifyUserRequest.java
@@ -30,6 +30,8 @@ class ServerRequestIdentifyUserRequest extends ServerRequest {
 
         callback_ = callback;
         userId_ = userId;
+        queueTimerId_ = 29;
+        requestTimerId_ = 30;
 
         JSONObject post = new JSONObject();
         try {

--- a/Branch-SDK/src/io/branch/referral/ServerRequestLogout.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestLogout.java
@@ -26,6 +26,8 @@ class ServerRequestLogout extends ServerRequest {
      */
     public ServerRequestLogout(Context context, Branch.LogoutStatusListener callback) {
         super(context, Defines.RequestPath.Logout.getPath());
+        queueTimerId_ = 13;
+        requestTimerId_ = 14;
         callback_ = callback;
         JSONObject post = new JSONObject();
         try {

--- a/Branch-SDK/src/io/branch/referral/ServerRequestRedeemRewards.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestRedeemRewards.java
@@ -32,7 +32,8 @@ class ServerRequestRedeemRewards extends ServerRequest {
      */
     public ServerRequestRedeemRewards(Context context, String bucketName, int numOfCreditsToRedeem, Branch.BranchReferralStateChangedListener callback) {
         super(context, Defines.RequestPath.RedeemRewards.getPath());
-
+        queueTimerId_ = 11;
+        requestTimerId_ = 12;
         callback_ = callback;
 
         int availableCredits = prefHelper_.getCreditCount(bucketName);

--- a/Branch-SDK/src/io/branch/referral/ServerRequestRegisterClose.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestRegisterClose.java
@@ -23,6 +23,8 @@ class ServerRequestRegisterClose extends ServerRequest {
     public ServerRequestRegisterClose(Context context) {
         super(context, Defines.RequestPath.RegisterClose.getPath());
         JSONObject closePost = new JSONObject();
+        queueTimerId_ = 9;
+        requestTimerId_ = 10;
         try {
             closePost.put(Defines.Jsonkey.DeviceFingerprintID.getKey(), prefHelper_.getDeviceFingerPrintID());
             closePost.put(Defines.Jsonkey.IdentityID.getKey(), prefHelper_.getIdentityID());

--- a/Branch-SDK/src/io/branch/referral/ServerRequestRegisterInstall.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestRegisterInstall.java
@@ -29,7 +29,8 @@ class ServerRequestRegisterInstall extends ServerRequestInitSession {
                                         SystemObserver sysObserver, String installID) {
 
         super(context, Defines.RequestPath.RegisterInstall.getPath());
-
+        queueTimerId_ = 1;
+        requestTimerId_ = 2;
         callback_ = callback;
         JSONObject installPost = new JSONObject();
         try {

--- a/Branch-SDK/src/io/branch/referral/ServerRequestRegisterOpen.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestRegisterOpen.java
@@ -26,7 +26,8 @@ class ServerRequestRegisterOpen extends ServerRequestInitSession {
     public ServerRequestRegisterOpen(Context context, Branch.BranchReferralInitListener callback,
                                      SystemObserver sysObserver) {
         super(context, Defines.RequestPath.RegisterOpen.getPath());
-
+        queueTimerId_ = 3;
+        requestTimerId_ = 4;
         callback_ = callback;
         JSONObject openPost = new JSONObject();
         try {

--- a/Branch-SDK/src/io/branch/referral/ServerRequestRegisterView.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestRegisterView.java
@@ -28,6 +28,8 @@ class ServerRequestRegisterView extends ServerRequest {
     public ServerRequestRegisterView(Context context, BranchUniversalObject branchUniversalObject, SystemObserver sysObserver, BranchUniversalObject.RegisterViewStatusListener callback) {
         super(context, Defines.RequestPath.RegisterView.getPath());
         callback_ = callback;
+        queueTimerId_ = 5;
+        requestTimerId_ = 6;
         JSONObject registerViewPost;
         try {
             registerViewPost = createContentViewJson(branchUniversalObject, sysObserver);

--- a/Branch-SDK/src/io/branch/referral/ServerRequestValidateReferralCode.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestValidateReferralCode.java
@@ -28,6 +28,8 @@ class ServerRequestValidateReferralCode extends ServerRequest {
         super(context, Defines.RequestPath.ValidateReferralCode.getPath());
 
         callback_ = callback;
+        queueTimerId_ = 7;
+        requestTimerId_ = 8;
         JSONObject post = new JSONObject();
         try {
             post.put(Defines.Jsonkey.IdentityID.getKey(), prefHelper_.getIdentityID());


### PR DESCRIPTION
As discussed with Sahil:

In order to gain a better sense of how long things are actually taking on the client side, I'd like to add the ability to be able to measure times on the client side, and send them back to the server. This shouldn't get in the way of any existing functionality, so it's a best-effort at most.

The basic model is, we have a timer repository where you can associate a timer id with a time value; then on every request, we will retrieve the currently stored timings, and send them up to the server, where we can do some kind of analysis.

The current things I have timed are: (1) time between when a ServerRequest object is created and when the request is actually started (hypothesis: it's possible the request is sitting on the AsyncTaskQueue for a while), and (2) time between request start and request end (we have server-side latencies, but it'd be good to get data on what the client-side latencies are).

Obviously, we'll only be able to collect request time data after a request is finished. We aren't going to make a separate request to send this timing data; instead, we'll just attach it to whatever request happens to go out next (and if there's not request... well, we're doing best-effort here). Note that we'll still be able to know *what* was timed, because it was associated with a specific timer id (e.g., the "/v1/open request time" timer id).

Additionally, I've added the capability for users to be able to add their own timers. In most cases, this won't be necessary, but if we are doing a deep integration, it could be useful to instrument on our end. I've reserved the first 1000 timer ids for us, and allowed partners to specify ids outside of that. It's possible we'll want to comment this out for public release.

Untested - not sure how...

@Sarkar @sojanpr 