### PR TITLE
Adding Instrumentation support

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -3011,9 +3011,6 @@ public class Branch {
 
         requestQueue_.enqueue(req);
         req.onRequestQueued();
-        HashMap<String, String> testMap = new HashMap<>();
-        testMap.put("Extra_data", "Userdata " + req.getRequestPath());
-        addExtraInstrumentationData(testMap);
         processNextQueueItem();
     }
 

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -3257,7 +3257,7 @@ public class Branch {
         @Override
         protected ServerResponse doInBackground(Void... voids) {
             //Update queue wait time
-            addExtraInstrumentationData(thisReq_.getRequestPath() + "-" + Defines.Jsonkey.Queue_Wait_Time.getKey(), "" + thisReq_.getQueueWaitTime());
+            addExtraInstrumentationData(thisReq_.getRequestPath() + "-" + Defines.Jsonkey.Queue_Wait_Time.getKey(), String.valueOf(thisReq_.getQueueWaitTime()));
 
             //Google ADs ID  and LAT value are updated using reflection. These method need background thread
             //So updating them for install and open on background thread.
@@ -4098,6 +4098,7 @@ public class Branch {
     public void addExtraInstrumentationData(String key, String value) {
         instrumentationExtraData_.put(key, value);
     }
+
 
 
 }

--- a/Branch-SDK/src/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/io/branch/referral/Defines.java
@@ -79,7 +79,9 @@ public class Defines {
 
         External_Intent_URI("external_intent_uri"),
         External_Intent_Extra("external_intent_extra"),
-        Last_Round_Trip_Time("lrtt");
+        Last_Round_Trip_Time("lrtt"),
+        Branch_Instrumentation("instrumentation"),
+        Queue_Wait_Time("qwt");
 
         
         private String key = "";

--- a/Branch-SDK/src/io/branch/referral/RemoteInterface.java
+++ b/Branch-SDK/src/io/branch/referral/RemoteInterface.java
@@ -125,9 +125,6 @@ class RemoteInterface {
 
             post.put("sdk", "android" + SDK_VERSION);
             post.put("retryNumber", retryNumber);
-            if (lastRoundTripTime_ > 0) {
-                post.put(Defines.Jsonkey.Last_Round_Trip_Time.getKey(), lastRoundTripTime_);
-            }
             if (!branch_key.equals(PrefHelper.NO_STRING_VALUE)) {
                 post.put(BRANCH_KEY, prefHelper_.getBranchKey());
                 return true;
@@ -185,7 +182,9 @@ class RemoteInterface {
             connection.setConnectTimeout(timeout);
             connection.setReadTimeout(timeout);
             lastRoundTripTime_ = (int) (System.currentTimeMillis() - reqStartTime);
-
+            if (Branch.getInstance() != null) {
+                Branch.getInstance().addExtraInstrumentationData(tag + "-" + Defines.Jsonkey.Last_Round_Trip_Time.getKey(), "" + lastRoundTripTime_);
+            }
 
             if (connection.getResponseCode() >= 500 &&
                     retryNumber < prefHelper_.getRetryCount()) {
@@ -344,6 +343,9 @@ class RemoteInterface {
             long reqStartTime = System.currentTimeMillis();
             OutputStreamWriter outputStreamWriter = new OutputStreamWriter(connection.getOutputStream());
             lastRoundTripTime_ = (int) (System.currentTimeMillis() - reqStartTime);
+            if (Branch.getInstance() != null) {
+                Branch.getInstance().addExtraInstrumentationData(tag + "-" + Defines.Jsonkey.Last_Round_Trip_Time.getKey(), "" + lastRoundTripTime_);
+            }
             outputStreamWriter.write(bodyCopy.toString());
             outputStreamWriter.flush();
 

--- a/Branch-SDK/src/io/branch/referral/RemoteInterface.java
+++ b/Branch-SDK/src/io/branch/referral/RemoteInterface.java
@@ -183,7 +183,7 @@ class RemoteInterface {
             connection.setReadTimeout(timeout);
             lastRoundTripTime_ = (int) (System.currentTimeMillis() - reqStartTime);
             if (Branch.getInstance() != null) {
-                Branch.getInstance().addExtraInstrumentationData(tag + "-" + Defines.Jsonkey.Last_Round_Trip_Time.getKey(), "" + lastRoundTripTime_);
+                Branch.getInstance().addExtraInstrumentationData(tag + "-" + Defines.Jsonkey.Last_Round_Trip_Time.getKey(), String.valueOf(lastRoundTripTime_));
             }
 
             if (connection.getResponseCode() >= 500 &&
@@ -344,7 +344,7 @@ class RemoteInterface {
             OutputStreamWriter outputStreamWriter = new OutputStreamWriter(connection.getOutputStream());
             lastRoundTripTime_ = (int) (System.currentTimeMillis() - reqStartTime);
             if (Branch.getInstance() != null) {
-                Branch.getInstance().addExtraInstrumentationData(tag + "-" + Defines.Jsonkey.Last_Round_Trip_Time.getKey(), "" + lastRoundTripTime_);
+                Branch.getInstance().addExtraInstrumentationData(tag + "-" + Defines.Jsonkey.Last_Round_Trip_Time.getKey(), String.valueOf(lastRoundTripTime_));
             }
             outputStreamWriter.write(bodyCopy.toString());
             outputStreamWriter.flush();

--- a/Branch-SDK/src/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequest.java
@@ -7,6 +7,9 @@ import android.content.pm.PackageManager;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
 /**
  * Abstract class defining the structure of a Branch Server request.
  */
@@ -18,6 +21,7 @@ public abstract class ServerRequest {
     private JSONObject params_;
     protected String requestPath_;
     protected PrefHelper prefHelper_;
+    long queueWaitTime_ = 0;
 
     /*True if there is an error in creating this request such as error with json parameters.*/
     public boolean constructError_ = false;
@@ -294,5 +298,45 @@ public abstract class ServerRequest {
     protected boolean doesAppHasInternetPermission(Context context) {
         int result = context.checkCallingOrSelfPermission(Manifest.permission.INTERNET);
         return result == PackageManager.PERMISSION_GRANTED;
+    }
+
+    /**
+     * Called when request is added to teh queue
+     */
+    public void onRequestQueued() {
+        queueWaitTime_ = System.currentTimeMillis();
+    }
+
+    /**
+     * Returns the amount of time this request was in queque
+     *
+     * @return {@link Integer} with value of queued time in milli sec
+     */
+    public long getQueueWaitTime() {
+        long waitTime = 0;
+        if (queueWaitTime_ > 0) {
+            waitTime = System.currentTimeMillis() - queueWaitTime_;
+        }
+        return waitTime;
+    }
+
+    /**
+     * Update the request parameters with instrumentation data
+     *
+     * @param dataMap A Map containing instrumentation data
+     */
+    public void updateInstrumentationData(ConcurrentHashMap<String, String> dataMap) {
+        if (dataMap.size() > 0) {
+            JSONObject instrObj = new JSONObject();
+            Set<String> keys = dataMap.keySet();
+            try {
+                for (String key : keys) {
+                    instrObj.put(key, dataMap.get(key));
+                    dataMap.remove(key);
+                }
+                params_.put(Defines.Jsonkey.Branch_Instrumentation.getKey(), instrObj);
+            } catch (JSONException ignore) {
+            }
+        }
     }
 }


### PR DESCRIPTION
Adding support for  Instrumentation data. This will provide a  way to
add Branch Instrumentation details such as request queue wait time ,
round trip time etc. It also provide option for partners to update any
instrumentation data through `addExtraInstrumentationData` api.

 Instrumentation details are  updated to Branch with next post request.

@dmitrig01 @Sarkar @aaustin 