### PR TITLE
Caturing external URI and Extra always

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -1289,6 +1289,28 @@ public class Branch {
     }
 
     private boolean readAndStripParam(Uri data, Activity activity) {
+
+        // Capture the intent URI and extra for analytics in case started by external intents such as  google app search
+        try {
+            if (data != null) {
+                prefHelper_.setExternalIntentUri(data.toString());
+            }
+            if (activity != null && activity.getIntent() != null && activity.getIntent().getExtras() != null) {
+                Bundle bundle = activity.getIntent().getExtras();
+                Set<String> extraKeys = bundle.keySet();
+
+                if (extraKeys.size() > 0) {
+                    JSONObject extrasJson = new JSONObject();
+                    for (String key : extraKeys) {
+                        extrasJson.put(key, bundle.get(key));
+                    }
+                    prefHelper_.setExternalIntentExtra(extrasJson.toString());
+                }
+            }
+        } catch (Exception ignore) {
+        }
+
+
         if (data != null && data.isHierarchical() && activity != null) {
             if (data.getQueryParameter(Defines.Jsonkey.LinkClickID.getKey()) != null) {
                 prefHelper_.setLinkClickIdentifier(data.getQueryParameter(Defines.Jsonkey.LinkClickID.getKey()));
@@ -1317,26 +1339,7 @@ public class Branch {
             }
         }
 
-        // If not started by Branch then check if there is any external URI on extra params
-        try {
-            if (data != null) {
-                prefHelper_.setExternalIntentUri(data.toString());
-            }
-            if (activity != null && activity.getIntent() != null && activity.getIntent().getExtras() != null) {
-                Bundle bundle = activity.getIntent().getExtras();
-                Set<String> extraKeys = bundle.keySet();
 
-                if (extraKeys.size() > 0) {
-                    JSONObject extrasJson = new JSONObject();
-                    for (String key : extraKeys) {
-                        extrasJson.put(key, bundle.get(key));
-                    }
-                    prefHelper_.setExternalIntentExtra(extrasJson.toString());
-                }
-            }
-        } catch (Exception ignore) {
-
-        }
 
 
         return false;


### PR DESCRIPTION
Earlier we used to capture this only if link-click-is is not present in
the intent URI. Capturing this always will needed considering the case
of google app search or other search app launching the app with
deplaned content.

 The Info is added with Open/Install post with following format
```”external_intent_uri": "branchtest:\/\/open",
   "external_intent_extra": "{\"android.intent.extra.REFERRER_NAME\":\"android-app:\\\/\\\/com.google.android.googlequicksearchbox\\\/https\\\/www.google.com\”}”,```

@aaustin @derrickstaten @dmitrig01 