### PR TITLE
Adding 100% deplane debug support

### DIFF
--- a/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
+++ b/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
@@ -305,6 +305,15 @@ public class MainActivity extends Activity {
             }
         });
 
+        // Add optional deep link debug params
+//        try {
+//            JSONObject debugObj = new JSONObject();
+//            debugObj.put("DeeplinkTestKey1", "DeeplinkTestValue1");
+//            debugObj.put("DeeplinkTestKey2", "DeeplinkTestValue2");
+//            Branch.getInstance().setDeepLinkDebugMode(debugObj);
+//        }catch (JSONException ignore){
+//        }
+
     }
 
     @Override

--- a/Branch-SDK/src/io/branch/indexing/BranchUniversalObject.java
+++ b/Branch-SDK/src/io/branch/indexing/BranchUniversalObject.java
@@ -486,7 +486,12 @@ public class BranchUniversalObject implements Parcelable {
         Branch branchInstance = Branch.getInstance();
         try {
             if (branchInstance != null && branchInstance.getLatestReferringParams() != null) {
+                // Check if link clicked. Unless deepvlink debug enabled return null if there is no link click
                 if (branchInstance.getLatestReferringParams().has("+clicked_branch_link") && branchInstance.getLatestReferringParams().getBoolean("+clicked_branch_link")) {
+                    branchUniversalObject = createInstance(branchInstance.getLatestReferringParams());
+                }
+                // If debug params are set then send BUO object even if link click is false
+                else if (branchInstance.getDeeplinkDebugParams() != null && branchInstance.getDeeplinkDebugParams().length() > 0) {
                     branchUniversalObject = createInstance(branchInstance.getLatestReferringParams());
                 }
             }

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -285,6 +285,9 @@ public class Branch {
      */
     private static final int PREVENT_CLOSE_TIMEOUT = 500;
 
+    /* Json object containing key-value pairs for debugging deep linking */
+    private JSONObject deeplinkDebugParams_;
+
     /**
      * <p>A {@link Branch} object that is instantiated on init and holds the singleton instance of
      * the class during application runtime.</p>
@@ -392,7 +395,6 @@ public class Branch {
         debugHandler_ = new Handler();
         debugStarted_ = false;
         linkCache_ = new HashMap<>();
-
     }
 
 
@@ -655,6 +657,15 @@ public class Branch {
     @Deprecated
     public void setDebug() {
         prefHelper_.setExternDebug();
+    }
+
+    /**
+     * Sets the key-value pairs for debugging the deep link. The key-value set in debug mode is given back with other deep link data on branch init session.
+     * This method should be called from onCreate() of activity which listens to Branch Init Session callbacks
+     * @param debugParams A {@link JSONObject} containing key-value pairs for debugging branch deep linking
+     */
+    public void setDeepLinkDebugMode(JSONObject debugParams){
+        deeplinkDebugParams_ = debugParams;
     }
 
     /**
@@ -1702,7 +1713,9 @@ public class Branch {
      */
     public JSONObject getFirstReferringParams() {
         String storedParam = prefHelper_.getInstallParams();
-        return convertParamsStringToDictionary(storedParam);
+        JSONObject firstReferringParams = convertParamsStringToDictionary(storedParam);
+        firstReferringParams = appendDebugParams(firstReferringParams);
+        return firstReferringParams;
     }
 
     /**
@@ -1717,7 +1730,33 @@ public class Branch {
      */
     public JSONObject getLatestReferringParams() {
         String storedParam = prefHelper_.getSessionParams();
-        return convertParamsStringToDictionary(storedParam);
+        JSONObject latestParams = convertParamsStringToDictionary(storedParam);
+        latestParams = appendDebugParams(latestParams);
+        return latestParams;
+    }
+
+    /**
+     * Append the deep link debug params to the original params
+     *
+     * @param originalParams A {@link JSONObject} original referrer parameters
+     * @return A new {@link JSONObject} with debug params appended.
+     */
+    private JSONObject appendDebugParams(JSONObject originalParams) {
+        try {
+            if (originalParams != null && deeplinkDebugParams_ != null) {
+                Iterator<String> keys = deeplinkDebugParams_.keys();
+                while (keys.hasNext()) {
+                    String key = keys.next();
+                    originalParams.put(key, deeplinkDebugParams_.get(key));
+                }
+            }
+        } catch (Exception ignore) {
+        }
+        return originalParams;
+    }
+
+    public JSONObject getDeeplinkDebugParams(){
+        return deeplinkDebugParams_;
     }
 
 

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -1744,6 +1744,9 @@ public class Branch {
     private JSONObject appendDebugParams(JSONObject originalParams) {
         try {
             if (originalParams != null && deeplinkDebugParams_ != null) {
+                if (deeplinkDebugParams_.length() > 0) {
+                    Log.w(TAG, "You're currently in deep link debug mode. Please comment out 'setDeepLinkDebugMode' to receive the deep link parameters from a real Branch link");
+                }
                 Iterator<String> keys = deeplinkDebugParams_.keys();
                 while (keys.hasNext()) {
                     String key = keys.next();
@@ -1755,7 +1758,10 @@ public class Branch {
         return originalParams;
     }
 
-    public JSONObject getDeeplinkDebugParams(){
+    public JSONObject getDeeplinkDebugParams() {
+        if (deeplinkDebugParams_ != null && deeplinkDebugParams_.length() > 0) {
+            Log.w(TAG, "You're currently in deep link debug mode. Please comment out 'setDeepLinkDebugMode' to receive the deep link parameters from a real Branch link");
+        }
         return deeplinkDebugParams_;
     }
 


### PR DESCRIPTION
Adding API setDeepLinkDebugMode() to set the deep link debug
parameters. These parameters are returned back 100 % time with init
session callbacks

Note: This method should be called from onCreate() of activity which
listens to Branch Init Session

@aaustin @Sarkar 