### PR TITLE
Fixing init issue with app links

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -1354,14 +1354,20 @@ public class Branch {
                 // Check if the clicked url is an app link pointing to this app
                 String scheme = data.getScheme();
                 if (scheme != null) {
-                    if ((scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https"))
-                            && data.getHost() != null && data.getHost().length() > 0 && data.getQueryParameter(Defines.Jsonkey.AppLinkUsed.getKey()) == null) {
-                        prefHelper_.setAppLink(data.toString());
-                        String uriString = data.toString();
-                        uriString += uriString.contains("?") ? "&" : "?";
-                        uriString += Defines.Jsonkey.AppLinkUsed.getKey() + "=true";
-                        activity.getIntent().setData(Uri.parse(uriString));
-                        return false;
+                    // On Launching app from the recent apps, Android Start the app with the original intent data. So up in opening app from recent list
+                    // Intent will have App link in data and lead to issue of getting wrong parameters. (In case of link click id since we are  looking for actual link click on back end this case will never happen)
+                    if ((activity.getIntent().getFlags() & Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) == 0) {
+                        if ((scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https"))
+                                && data.getHost() != null && data.getHost().length() > 0 && data.getQueryParameter(Defines.Jsonkey.AppLinkUsed.getKey()) == null) {
+                            prefHelper_.setAppLink(data.toString());
+                            String uriString = data.toString();
+                            uriString += uriString.contains("?") ? "&" : "?";
+                            uriString += Defines.Jsonkey.AppLinkUsed.getKey() + "=true";
+                            activity.getIntent().setData(Uri.parse(uriString));
+                            return false;
+                        }
+                        Log.d("LaunchTEst", "Launched Directly");
+
                     }
                 }
             }

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -1355,11 +1355,14 @@ public class Branch {
                 String scheme = data.getScheme();
                 if (scheme != null) {
                     if ((scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https"))
-                            && data.getHost() != null && data.getHost().length() > 0) {
+                            && data.getHost() != null && data.getHost().length() > 0 && data.getQueryParameter(Defines.Jsonkey.AppLinkUsed.getKey()) == null) {
                         prefHelper_.setAppLink(data.toString());
+                        String uriString = data.toString();
+                        uriString += uriString.contains("?") ? "&" : "?";
+                        uriString += Defines.Jsonkey.AppLinkUsed.getKey() + "=true";
+                        activity.getIntent().setData(Uri.parse(uriString));
                         return false;
                     }
-
                 }
             }
         }

--- a/Branch-SDK/src/io/branch/referral/BranchRemoteInterface.java
+++ b/Branch-SDK/src/io/branch/referral/BranchRemoteInterface.java
@@ -95,7 +95,7 @@ public class BranchRemoteInterface extends RemoteInterface {
                     post.put(Defines.Jsonkey.IdentityID.getKey(), prefHelper_.getIdentityID());
                 }
                 callback_.finished(make_restful_post(post, prefHelper_.getAPIBaseUrl() + urlExtend, PrefHelper.REQ_TAG_DEBUG_CONNECT, prefHelper_.getTimeout(), true));
-            } catch (JSONException ex) {
+            } catch (Exception ex) {
                 ex.printStackTrace();
             }
         }

--- a/Branch-SDK/src/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/io/branch/referral/Defines.java
@@ -14,6 +14,7 @@ public class Defines {
         DeviceFingerprintID("device_fingerprint_id"),
         SessionID("session_id"),
         LinkClickID("link_click_id"),
+        AppLinkUsed("branch_used"),
 
         Bucket("bucket"),
         DefaultBucket("default"),

--- a/Branch-SDK/src/io/branch/referral/SystemObserver.java
+++ b/Branch-SDK/src/io/branch/referral/SystemObserver.java
@@ -327,7 +327,7 @@ class SystemObserver {
             if (bluetoothAdapter != null) {
                 return bluetoothAdapter.isEnabled();
             }
-        } catch (SecurityException ignored ) {
+        } catch (Exception ignore) {
         }
         return false;
     }
@@ -353,13 +353,16 @@ class SystemObserver {
      * </ul>
      */
     public String getBluetoothVersion() {
-        if (android.os.Build.VERSION.SDK_INT >= 8) {
-            if (android.os.Build.VERSION.SDK_INT >= 18 &&
-                    context_.getPackageManager().hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE)) {
-                return "ble";
-            } else if (context_.getPackageManager().hasSystemFeature(PackageManager.FEATURE_BLUETOOTH)) {
-                return "classic";
+        try {
+            if (android.os.Build.VERSION.SDK_INT >= 8) {
+                if (android.os.Build.VERSION.SDK_INT >= 18 &&
+                        context_.getPackageManager().hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE)) {
+                    return "ble";
+                } else if (context_.getPackageManager().hasSystemFeature(PackageManager.FEATURE_BLUETOOTH)) {
+                    return "classic";
+                }
             }
+        } catch (Exception ignore) {
         }
         return BLANK;
     }


### PR DESCRIPTION
Marking the app link in the intent as used once it is used for getting
deep link params in order to prevent providing wrong deep link data.

@aaustin 