### PR TITLE
safeguard against NPE if getNetworkInfo invalid

### DIFF
--- a/Branch-SDK/src/io/branch/referral/SystemObserver.java
+++ b/Branch-SDK/src/io/branch/referral/SystemObserver.java
@@ -604,7 +604,7 @@ class SystemObserver {
         if (PackageManager.PERMISSION_GRANTED == context_.checkCallingOrSelfPermission(Manifest.permission.ACCESS_NETWORK_STATE)) {
             ConnectivityManager connManager = (ConnectivityManager) context_.getSystemService(Context.CONNECTIVITY_SERVICE);
             NetworkInfo wifiInfo = connManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
-            return wifiInfo.isConnected();
+            return ((wifiInfo != null) && wifiInfo.isConnected());
         }
         return false;
     }


### PR DESCRIPTION
@sojanpr @aaustin 

if someone specifies <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE "/>, we determine if wifi is connected upon a new user install.

In some cases, the class that retrieves this network property can be invalid, which returns null: http://developer.android.com/reference/android/net/ConnectivityManager.html#getNetworkInfo(android.net.Network)

we don't check for null before returning, leading to a crash: http://crashes.to/s/40d5b581afa