### PR TITLE
Format Change for Long link

### DIFF
--- a/Branch-SDK/src/io/branch/referral/ServerRequestCreateUrl.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestCreateUrl.java
@@ -180,7 +180,7 @@ class ServerRequestCreateUrl extends ServerRequest {
      * @return A {@link String} url with given deep link parameters
      */
     private String generateLongUrlWithParams(String baseUrl) {
-        String longUrl = baseUrl + "?";
+        String longUrl = baseUrl + "&";  // Base url already has "?"
         Collection<String> tags = linkPost_.getTags();
         if (tags != null) {
             for (String tag : tags) {


### PR DESCRIPTION
long link format changed to  `[link base] + & + [query parameters]`
since link already contains ? now.

@dmitrig01  @aaustin 