### PR TITLE
Add extras to requests

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -679,7 +679,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents {
     /**
      * <p>Add key value pairs to all requests</p>
      */
-    public void addMetadataToRequests(@NonNull String key, JSONObject value) {
+    public void addMetadataToRequests(@NonNull String key, Object value) {
         prefHelper_.setRequestMetadata(key, value);
     }
 

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -679,7 +679,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents {
     /**
      * <p>Add key value pairs to all requests</p>
      */
-    public void addMetadataToRequests(@NonNull String key, Object value) {
+    public void setRequestMetadata(@NonNull String key, @NonNull String value) {
         prefHelper_.setRequestMetadata(key, value);
     }
 

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -677,6 +677,13 @@ public class Branch implements BranchViewHandler.IBranchViewEvents {
     }
 
     /**
+     * <p>Add key value pairs to all requests</p>
+     */
+    public void addMetadataToRequests(@NonNull String key, JSONObject value) {
+        prefHelper_.setRequestMetadata(key, value);
+    }
+
+    /**
      * <p>Initialises a session with the Branch API, assigning a {@link BranchUniversalReferralInitListener}
      * to perform an action upon successful initialisation.</p>
      *

--- a/Branch-SDK/src/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/io/branch/referral/PrefHelper.java
@@ -1032,7 +1032,15 @@ public class PrefHelper {
         BNC_Smart_Session = false;
     }
 
-    public void setRequestMetadata(@NonNull String key, Object value) {
+    public void setRequestMetadata(@NonNull String key, @NonNull String value) {
+        if (key == null) {
+            return;
+        }
+
+        if (this.requestMetadata.has(key) && value == null) {
+            this.requestMetadata.remove(key);
+        }
+
         try {
             this.requestMetadata.put(key, value);
         } catch (JSONException e) {

--- a/Branch-SDK/src/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/io/branch/referral/PrefHelper.java
@@ -1032,7 +1032,7 @@ public class PrefHelper {
         BNC_Smart_Session = false;
     }
 
-    public void setRequestMetadata(@NonNull String key, JSONObject value) {
+    public void setRequestMetadata(@NonNull String key, Object value) {
         try {
             this.requestMetadata.put(key, value);
         } catch (JSONException e) {

--- a/Branch-SDK/src/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/io/branch/referral/PrefHelper.java
@@ -6,9 +6,11 @@ import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
+import android.support.annotation.NonNull;
 import android.util.Log;
 
 import org.json.JSONException;
+import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -113,6 +115,11 @@ public class PrefHelper {
     private BranchRemoteInterface remoteInterface_;
 
     /**
+     * Arbitrary key values added to all requests.
+     */
+    private JSONObject requestMetadata;
+
+    /**
      * Reference of application {@link Context}, normally the base context of the application.
      */
     private Context context_;
@@ -135,6 +142,7 @@ public class PrefHelper {
                 Context.MODE_PRIVATE);
         this.prefsEditor_ = this.appSharedPrefs_.edit();
         this.context_ = context;
+        this.requestMetadata = new JSONObject();
     }
 
     /**
@@ -1022,6 +1030,18 @@ public class PrefHelper {
      */
     public void disableSmartSession() {
         BNC_Smart_Session = false;
+    }
+
+    public void setRequestMetadata(@NonNull String key, JSONObject value) {
+        try {
+            this.requestMetadata.put(key, value);
+        } catch (JSONException e) {
+            // no-op
+        }
+    }
+
+    public JSONObject getRequestMetadata() {
+        return this.requestMetadata;
     }
 
     /**

--- a/Branch-SDK/src/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequest.java
@@ -138,10 +138,26 @@ public abstract class ServerRequest {
      *             as key-value pairs.
      */
     protected void setPost(JSONObject post) {
+        // Take event level metadata, merge with top level metadata
+        // event level metadata takes precedence
         try {
-            post.put("metadata", prefHelper_.getRequestMetadata());
+            JSONObject metadata = new JSONObject();
+            Iterator<String> i = prefHelper_.getRequestMetadata().keys();
+            while (i.hasNext()) {
+                String k = i.next();
+                metadata.put(k, prefHelper_.getRequestMetadata().get(k));
+            }
+            if (post.has(Defines.Jsonkey.Metadata.getKey())) {
+                Iterator<String> postIter = post.getJSONObject(Defines.Jsonkey.Metadata.getKey()).keys();
+                while (postIter.hasNext()) {
+                    String key = postIter.next();
+                    // override keys from above
+                    metadata.put(key, post.getJSONObject(Defines.Jsonkey.Metadata.getKey()).get(key));
+                }
+            }
+            post.put(Defines.Jsonkey.Metadata.getKey(), metadata);
         } catch (JSONException e) {
-            Log.e("BRANCH", "couldn't add metadata to request, ignoring");
+            Log.e("BranchSDK", "Could not merge metadatas, ignoring user metadata.");
         }
         params_ = post;
         DeviceInfo.getInstance(prefHelper_.getExternDebug(), systemObserver_).updateRequestWithDeviceParams(params_);

--- a/Branch-SDK/src/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequest.java
@@ -3,6 +3,7 @@ package io.branch.referral;
 import android.Manifest;
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -137,6 +138,11 @@ public abstract class ServerRequest {
      *             as key-value pairs.
      */
     protected void setPost(JSONObject post) {
+        try {
+            post.put("metadata", prefHelper_.getRequestMetadata());
+        } catch (JSONException e) {
+            Log.e("BRANCH", "couldn't add metadata to request, ignoring");
+        }
         params_ = post;
         DeviceInfo.getInstance(prefHelper_.getExternDebug(), systemObserver_).updateRequestWithDeviceParams(params_);
     }


### PR DESCRIPTION
@sojanpr 

the goal is to add an extra entry to all requests, called "metadata". inside it, anyone can specify a key with any type of value. 

we whitelist values on the server - something to keep in mind. 

usage: should be added after get instance but before initSession. can be added after getAutoInstance. 